### PR TITLE
fix(auth): remove sensetive mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,86 @@
+# Task Management API
 
- 
-## Technologies 
+A robust, modular, and secure RESTful API for managing tasks, users, projects, and collaborations. Built with Spring Boot, PostgreSQL, JWT authentication, and follows best practices for clean architecture and validation.
+
+## Technologies
+
 - Spring Boot (v3.5.0)
 - Spring Data JPA
 - Spring Validation
 - Spring Security + JWT Token
 - PostgreSQL
-- Mapstruct
+- MapStruct
 - Lombok
 - Swagger (Open API)
+
+## Features
+
+- **User Management**: Registration, login, roles, and session management.
+- **Task & Project Management**: Entities for tasks, projects, collaboration, and notifications.
+- **Authentication & Authorization**: JWT-based security, role-based access control.
+- **Validation**: Strong validation with custom messages.
+- **API Documentation**: Swagger/OpenAPI integration.
+- **Docker Support**: Dockerfile and docker-compose for easy setup.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.8+
+- Docker & Docker Compose (for containerized setup)
+- PostgreSQL (if not using Docker)
+
+### Environment Variables
+
+Configure your `.env` file (see `.env` in the project root) for database and JWT secrets.
+
+### Running with Docker
+
+```sh
+docker-compose up --build
+```
+
+- This will start the API and a PostgreSQL database using the provided `docker-compose.yml`.
+
+### Running Locally
+
+1. Create and configure your database (see `init-db.sql`).
+2. Update `src/main/resources/application.yml` with your DB credentials.
+3. Build and run:
+
+```sh
+mvn clean install
+mvn spring-boot:run
+```
+
+### API Documentation
+
+- Swagger UI: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+- OpenAPI docs: [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs)
+
+### Main Endpoints
+
+| Endpoint                 | Description                |
+|--------------------------|----------------------------|
+| POST `/api/v1/auth/register` | User registration         |
+| POST `/api/v1/auth/login`    | User login (JWT issued)   |
+| ...                      | (See Swagger for more)     |
+
+### Project Structure
+
+- `src/main/java/com/omori/taskmanagement/springboot/model` - Domain models (User, Role, Task, Project, etc.)
+- `src/main/java/com/omori/taskmanagement/springboot/controller` - REST controllers (authentication, etc.)
+- `src/main/java/com/omori/taskmanagement/springboot/security` - Security config, JWT, DTOs, mappers
+- `src/main/resources/messages/validation` - Custom validation messages
+- `init-db.sql` - Database schema and seed data
+
+### Contribution
+
+1. Fork this repo and create your branch from `dev`.
+2. Make your changes.
+3. Open a PR to `dev` with a clear description.
+
+### License
+
+See [LICENSE](LICENSE) for details.

--- a/src/main/java/com/omori/taskmanagement/springboot/security/dto/AuthenticatedUserDto.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/security/dto/AuthenticatedUserDto.java
@@ -14,7 +14,6 @@ public class AuthenticatedUserDto {
 
 	private String username;
 
-	private String password;
 
 	private Role role;
 

--- a/src/main/java/com/omori/taskmanagement/springboot/security/mapper/UserMapper.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/security/mapper/UserMapper.java
@@ -37,7 +37,6 @@ public abstract class UserMapper {
     
     public abstract User convertToUser(RegistrationRequest registrationRequest);
 
-    @Mapping(target = "password", source = "passwordHash")
     public abstract AuthenticatedUserDto convertToAuthenticatedUserDto(User user);
 
     public abstract User convertToUser(AuthenticatedUserDto authenticatedUserDto);

--- a/src/main/java/com/omori/taskmanagement/springboot/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/security/service/UserDetailsServiceImpl.java
@@ -27,15 +27,15 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 	@Override
 	public UserDetails loadUserByUsername(String username) {
 
-		final AuthenticatedUserDto authenticatedUser = userService.findAuthenticatedUserByUsername(username);
+		final com.omori.taskmanagement.springboot.model.usermgmt.User user = userService.findByUsername(username);
 
-		if (Objects.isNull(authenticatedUser)) {
+		if (Objects.isNull(user)) {
 			throw new UsernameNotFoundException(USERNAME_OR_PASSWORD_INVALID);
 		}
 
-		final String authenticatedUsername = authenticatedUser.getUsername();
-		final String authenticatedPassword = authenticatedUser.getPassword();
-		final Role userRole = authenticatedUser.getRole();
+		final String authenticatedUsername = user.getUsername();
+		final String authenticatedPassword = user.getPasswordHash();
+		final Role userRole = user.getRole();
 		final SimpleGrantedAuthority grantedAuthority = new SimpleGrantedAuthority(userRole.getName());
 
 		return new User(authenticatedUsername, authenticatedPassword, Collections.singletonList(grantedAuthority));


### PR DESCRIPTION
Removed sensitive mapping:
In UserMapper.java, the mapping that assigned passwordHash to password in AuthenticatedUserDto has been removed. This prevents any password hash from being exposed in DTOs returned to clients.
Removed password field from DTO:
In AuthenticatedUserDto.java, the password field was removed entirely. This ensures that password data cannot be accidentally serialized or exposed in any API response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and restructured the README to provide a comprehensive project overview, detailed usage instructions, API endpoint summaries, project structure, contribution guidelines, and license information.

* **Refactor**
  * Removed the password field from user authentication data transfer objects, ensuring sensitive information is no longer stored or transferred unnecessarily.
  * Updated user authentication logic to retrieve user information directly from the user entity, improving data handling and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->