### PR TITLE
Fix: resolve Redis caching serialization issues and Jackson dependency conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,5 @@ application-prod.yml
 .env
 .DS_Store
 getTaskwFilter.json
-CLAUDE.md
 .gitignore
-.github/
 zeon/

--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,12 @@
             <artifactId>spring-session-data-redis</artifactId>
         </dependency>
 
-        <dependency>
+        <!-- <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
-        </dependency>
+        </dependency> -->
 
         <dependency>
             <groupId>com.auth0</groupId>
@@ -150,16 +150,20 @@
             <version>2.21.1</version>
         </dependency> -->
 
+        <!-- Jackson dependencies - let Spring Boot manage versions -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.3</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/omori/taskmanagement/springboot/config/RedisConfig.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/config/RedisConfig.java
@@ -1,6 +1,11 @@
 package com.omori.taskmanagement.springboot.config;
 
-import io.swagger.v3.core.util.Json;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
@@ -17,10 +22,6 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,81 +31,106 @@ import java.util.Map;
 @EnableCaching
 public class RedisConfig {
 
-    @Value("${spring.redis.host:localhost}")
-    private String redisHost;
+        @Value("${spring.redis.host:localhost}")
+        private String redisHost;
 
-    @Value("${spring.redis.port:6379}")
-    private int redisPort;
+        @Value("${spring.redis.port:6379}")
+        private int redisPort;
 
-    @Value("${spring.redis.password:}")
-    private String redisPassword;
+        @Value("${spring.redis.password:}")
+        private String redisPassword;
 
-    @Value("${spring.redis.timeout:5000}")
-    private long timeout;
+        @Value("${spring.redis.timeout:5000}")
+        private long timeout;
 
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        log.info("Configuring Redis connection to {}:{}", redisHost, redisPort);
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(redisHost);
-        config.setPort(redisPort);
-        
-        if (redisPassword != null && !redisPassword.isEmpty()) {
-            config.setPassword(redisPassword);
+        @Bean
+        public RedisConnectionFactory redisConnectionFactory() {
+                log.info("Configuring Redis connection to {}:{}", redisHost, redisPort);
+                RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+                config.setHostName(redisHost);
+                config.setPort(redisPort);
+
+                if (redisPassword != null && !redisPassword.isEmpty()) {
+                        config.setPassword(redisPassword);
+                }
+
+                LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                                .commandTimeout(Duration.ofMillis(timeout))
+                                .shutdownTimeout(Duration.ZERO)
+                                .build();
+
+                return new LettuceConnectionFactory(config, clientConfig);
         }
-        
-        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
-                .commandTimeout(Duration.ofMillis(timeout))
-                .shutdownTimeout(Duration.ZERO)
-                .build();
-                
-        return new LettuceConnectionFactory(config, clientConfig);
-    }
 
-    @Bean
-    public RedisCacheConfiguration cacheConfiguration() {
-        // Create a custom ObjectMapper for Redis serialization
-        ObjectMapper redisObjectMapper = JsonMapper.builder()
-                .addModule(new JavaTimeModule())
-                .build();
-        
-        // Configure the Redis serializer with the custom ObjectMapper
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
-        
-        return RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(60))  // Default TTL for all caches
-                .disableCachingNullValues()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
-    }
+        @Bean
+        public RedisCacheConfiguration cacheConfiguration() {
+                ObjectMapper redisObjectMapper = JsonMapper.builder()
+                                .addModule(new JavaTimeModule())
+                                .build();
 
-    @Bean
-    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+                // Các cấu hình quan trọng
+                redisObjectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+                redisObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+                redisObjectMapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+                redisObjectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
-        // create a custom ObjectMapper for Redis serializations
-        ObjectMapper redisObjectMapper = JsonMapper.builder()
-                .addModule(new JavaTimeModule())
-                .build();
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
-        
-        // Configuration for tasks cache
-        cacheConfigurations.put("tasks", RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(30))
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair
-                        .fromSerializer(serializer)));
-        
-        // Configuration for taskDetails cache
-        cacheConfigurations.put("taskDetails", RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofHours(1))
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair
-                        .fromSerializer(serializer)));
+                // Chỉ enable type info nếu thực sự cần polymorphism
+                redisObjectMapper.activateDefaultTyping(
+                                redisObjectMapper.getPolymorphicTypeValidator(),
+                                ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE,
+                                JsonTypeInfo.As.PROPERTY);
 
-        return RedisCacheManager.builder(redisConnectionFactory)
-                .cacheDefaults(cacheConfiguration())
-                .withInitialCacheConfigurations(cacheConfigurations)
-                .build();
-    }
+                GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
+                                redisObjectMapper);
+
+                return RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofMinutes(60))
+                                .disableCachingNullValues()
+                                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                                                .fromSerializer(new StringRedisSerializer()))
+                                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                                                .fromSerializer(serializer));
+        }
+
+        @Bean
+        public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+                Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+                // Create ObjectMapper with type information for Redis serialization only
+                ObjectMapper redisObjectMapper = JsonMapper.builder()
+                                .addModule(new JavaTimeModule())
+                                .build();
+                redisObjectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                redisObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+                // Enable default typing for Redis serialization only
+                redisObjectMapper.activateDefaultTyping(
+                                redisObjectMapper.getPolymorphicTypeValidator(),
+                                ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE,
+                                JsonTypeInfo.As.PROPERTY);
+
+                GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(
+                                redisObjectMapper);
+
+                // Configuration for tasks cache
+                cacheConfigurations.put("tasks", RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofMinutes(30))
+                                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                                                .fromSerializer(new StringRedisSerializer()))
+                                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                                                .fromSerializer(serializer)));
+
+                // Configuration for taskDetails cache
+                cacheConfigurations.put("taskDetails", RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofHours(1))
+                                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                                                .fromSerializer(new StringRedisSerializer()))
+                                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                                                .fromSerializer(serializer)));
+
+                return RedisCacheManager.builder(redisConnectionFactory)
+                                .cacheDefaults(cacheConfiguration())
+                                .withInitialCacheConfigurations(cacheConfigurations)
+                                .build();
+        }
 }

--- a/src/main/java/com/omori/taskmanagement/springboot/dto/project/GetTaskResponse.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/dto/project/GetTaskResponse.java
@@ -1,16 +1,30 @@
 package com.omori.taskmanagement.springboot.dto.project;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.omori.taskmanagement.springboot.model.project.Task;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
-@Data
+@JsonIgnoreProperties(ignoreUnknown = true) // ignore unknown properties during deserialization
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
 @Builder
-public class GetTaskResponse {
+public class GetTaskResponse implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private UUID uuid;
     private String title;
@@ -32,7 +46,7 @@ public class GetTaskResponse {
     private Map<String, Object> metadata;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    
+
     public static GetTaskResponse from(Task task) {
         return GetTaskResponse.builder()
                 .id(task.getId())
@@ -57,5 +71,31 @@ public class GetTaskResponse {
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        GetTaskResponse that = (GetTaskResponse) o;
+        return Objects.equals(id, that.id) && Objects.equals(uuid, that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, uuid);
+    }
+
+    @Override
+    public String toString() {
+        return "GetTaskResponse{" +
+                "id=" + id +
+                ", uuid=" + uuid +
+                ", title='" + title + '\'' +
+                ", status=" + status +
+                ", priority=" + priority +
+                '}';
     }
 }

--- a/src/main/java/com/omori/taskmanagement/springboot/model/audit/JsonbConverter.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/model/audit/JsonbConverter.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.util.Map;
 
-@Converter(autoApply = true)
+@Converter(autoApply = false)
 public class JsonbConverter implements AttributeConverter<Map<String, Object>, String> {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()

--- a/src/main/java/com/omori/taskmanagement/springboot/utils/ObjectDiffUtils.java
+++ b/src/main/java/com/omori/taskmanagement/springboot/utils/ObjectDiffUtils.java
@@ -4,6 +4,9 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class ObjectDiffUtils {
 
     public static Map<String, Object> getObjectAsMap(Object obj) {
@@ -24,7 +27,7 @@ public class ObjectDiffUtils {
                 }
             }
         } catch(IllegalAccessException e) {
-            e.printStackTrace();
+            log.error("Error while getting object as map", e);
         }
         return map;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,14 +3,14 @@ server:
     enabled: true
 
 spring:
-  devtools:
-    add-properties: false
-    restart:
-      enabled: true
-      exclude: static/**,public/**,templates/**
-    livereload:
-      enabled: true
-      port: 35729
+  # devtools:
+  #   add-properties: false
+  #   restart:
+  #     enabled: false
+  #     exclude: static/**,public/**,templates/**
+  #   livereload:
+  #     enabled: true
+  #     port: 35729
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}


### PR DESCRIPTION
	•	Fix Jackson dependency version conflicts in pom.xml by removing explicit versions
	•	Add jackson-annotations dependency to resolve @JsonTypeInfo compilation errors
	•	Refactor RedisConfig to isolate Redis ObjectMapper from main application serialization
	•	Add proper type information handling for GetTaskResponse Redis caching
	•	Configure JavaTimeModule and disable timestamp arrays for consistent date formatting
	•	Update JsonbConverter to use proper ObjectMapper configuration
	•	Resolve ClassCastException: LinkedHashMap cannot be cast to GetTaskResponse
	•	Clean up ObjectDiffUtils and application.yml configuration
	•	Update .gitignore for better project structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Redis cache and connection configuration, including enhanced JSON serialization and differentiated cache expiration times.
  * Updated project dependencies to allow Spring Boot to manage Jackson versions and added a new Jackson annotation dependency.
  * Adjusted JPA JSON converter to require explicit usage instead of automatic application.
  * Enhanced error handling in object diff utilities with improved logging.

* **Bug Fixes**
  * Improved task response handling for better JSON compatibility and equality checks.

* **Chores**
  * Disabled Spring Boot DevTools in configuration and build files.
  * Updated ignore rules to include all files and directories previously specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->